### PR TITLE
Atlas Runner Death % and Completion % Overlay

### DIFF
--- a/VillageHelper.cs
+++ b/VillageHelper.cs
@@ -368,11 +368,11 @@ public class VillageHelper : BaseSettingsPlugin<VillageHelperSettings>
                             var chanceToDieText = $"{chanceToDie}%";
                             var chanceToDieTextSize = Graphics.MeasureText(chanceToDieText);
                             var chanceToDieTextPlacement = map.GetClientRectCache.TopRight.ToVector2Num();                        
-                            chanceToDieTextPlacement.X -= (chanceToDieTextSize.X/2 + map.GetClientRectCache.Width/2);
+                            chanceToDieTextPlacement.X -= map.GetClientRectCache.Width/2;
                             chanceToDieTextPlacement.Y -= 25;
 
                             // Draw the chance to die
-                            Graphics.DrawTextWithBackground(chanceToDieText, chanceToDieTextPlacement, chanceColor, Color.Black);
+                            Graphics.DrawTextWithBackground(chanceToDieText, chanceToDieTextPlacement, chanceColor, FontAlign.Center, Color.Black);
                         }
                     }
 
@@ -396,15 +396,15 @@ public class VillageHelper : BaseSettingsPlugin<VillageHelperSettings>
                             // Calculate the color based on the average chance to complete
                             var completionColor = averageChance switch
                             {
-                                < 65 => Settings.BadColor,
-                                < 85 => Settings.NeutralColor,
+                                < 45 => Settings.BadColor,
+                                < 65 => Settings.NeutralColor,
                                 _ => Settings.GoodColor
                             };
                             
                             var chanceToCompleteText = $"{averageChance}%";
                             var chanceToCompleteTextSize = Graphics.MeasureText(chanceToCompleteText);
                             var chanceToCompleteTextPlacement = map.GetClientRectCache.BottomRight.ToVector2Num();
-                            chanceToCompleteTextPlacement.X -= chanceToCompleteTextSize.X;///2 + map.GetClientRectCache.Width/2);
+                            chanceToCompleteTextPlacement.X -= map.GetClientRectCache.Width/2;
                             chanceToCompleteTextPlacement.Y += 5;
 
                             // Draw the average chance to complete

--- a/VillageHelperSettings.cs
+++ b/VillageHelperSettings.cs
@@ -18,10 +18,13 @@ public class VillageHelperSettings : ISettings
     public ToggleNode ShowEmptyResources { get; set; } = new ToggleNode(true);
     public ToggleNode ShowEmptyResourcesInColor { get; set; } = new ToggleNode(true);
     public ToggleNode ShowStatusOverlay { get; set; } = new ToggleNode(true);
+    public ToggleNode ShowAverageMapCompletionPercent { get; set; } = new ToggleNode(true);
+    public ToggleNode ShowMapperDeathChance { get; set; } = new ToggleNode(true);
     public RangeNode<int> StatusOverlayXOffset { get; set; } = new RangeNode<int>(0, 0, 200);
     public RangeNode<int> StatusOverlayYOffset { get; set; } = new RangeNode<int>(0, 0, 200);
     public RangeNode<float> StatusOverlayUpdatePeriod { get; set; } = new(1, 0, 10);
     public ToggleNode ShowProjectedCurrentGold { get; set; } = new ToggleNode(false);
+
 
     public ToggleNode ShowWorkerUpgradeTips { get; set; } = new ToggleNode(true);
     public ColorNode GoodColor { get; set; } = new ColorNode(Color.Green);


### PR DESCRIPTION
This adds a death % and average completion % overlay to the atlas runner interface.

![image](https://github.com/user-attachments/assets/d630c39e-4d05-4f91-a0aa-a09cc0b3fa81)
